### PR TITLE
added decorator to RequestTypeProvider class

### DIFF
--- a/src/main/java/ru/pezhe/cmanager/requests/CmanagerApp.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/CmanagerApp.java
@@ -4,18 +4,22 @@ import ru.pezhe.cmanager.requests.entity.Request;
 import ru.pezhe.cmanager.requests.entity.RequestOption;
 import ru.pezhe.cmanager.requests.service.IdProvider;
 import ru.pezhe.cmanager.requests.service.PublicServiceProvider;
+import ru.pezhe.cmanager.requests.service.RequestTypeExtendedProvider;
 import ru.pezhe.cmanager.requests.service.RequestTypeProvider;
 
 public class CmanagerApp {
 
     public static void main(String[] args) {
 
+        RequestTypeExtendedProvider typeProvider = new RequestTypeExtendedProvider(RequestTypeProvider.getInstance());
+        System.out.println(typeProvider.getTypeList("stub_type_1", "stub_type_2"));
+
         Request createdRequest = Request.builder()
                 .id(IdProvider.getNewId())
                 .requestorId("some_id_1")
                 .apartmentId("some_id_2")
                 .service(PublicServiceProvider.getInstance().getByName("stub_service"))
-                .type(RequestTypeProvider.getInstance().getByName("stub_type"))
+                .type(typeProvider.getByName("stub_type_1"))
                 .description("Problem description")
                 .option(new RequestOption(IdProvider.getNewId(), "option_1").addValue("some_value"))
                 .build();

--- a/src/main/java/ru/pezhe/cmanager/requests/service/PublicServiceProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/PublicServiceProvider.java
@@ -1,22 +1,24 @@
 package ru.pezhe.cmanager.requests.service;
 
 import ru.pezhe.cmanager.requests.entity.PublicService;
+import ru.pezhe.cmanager.requests.service.common.SimpleProvider;
 
 
-public class PublicServiceProvider {
+public class PublicServiceProvider implements SimpleProvider {
 
     private final PublicService stubService;
     private final static PublicServiceProvider instance = new PublicServiceProvider();
 
     private PublicServiceProvider() {
         this.stubService = new PublicService("id", "stub_service", "none");
-        this.stubService.getSupportedRequestTypes().add("stub_type");
+        this.stubService.getSupportedRequestTypes().add("stub_type_1");
     }
 
     public static PublicServiceProvider getInstance() {
         return instance;
     }
 
+    @Override
     public PublicService getByName(String serviceName) {
         return this.stubService;
     }

--- a/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeExtendedProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeExtendedProvider.java
@@ -2,7 +2,6 @@ package ru.pezhe.cmanager.requests.service;
 
 import ru.pezhe.cmanager.requests.entity.RequestType;
 import ru.pezhe.cmanager.requests.service.common.ComplexProvider;
-import ru.pezhe.cmanager.requests.service.common.SimpleProvider;
 
 import java.util.Arrays;
 import java.util.List;
@@ -10,8 +9,8 @@ import java.util.stream.Collectors;
 
 public class RequestTypeExtendedProvider extends ComplexProvider {
 
-    public RequestTypeExtendedProvider(SimpleProvider simpleProvider) {
-        super(simpleProvider);
+    public RequestTypeExtendedProvider(RequestTypeProvider provider) {
+        super(provider);
     }
 
     @Override

--- a/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeExtendedProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeExtendedProvider.java
@@ -1,0 +1,28 @@
+package ru.pezhe.cmanager.requests.service;
+
+import ru.pezhe.cmanager.requests.entity.RequestType;
+import ru.pezhe.cmanager.requests.service.common.ComplexProvider;
+import ru.pezhe.cmanager.requests.service.common.SimpleProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RequestTypeExtendedProvider extends ComplexProvider {
+
+    public RequestTypeExtendedProvider(SimpleProvider simpleProvider) {
+        super(simpleProvider);
+    }
+
+    @Override
+    public RequestType getByName(String name) {
+        return (RequestType)provider.getByName(name);
+    }
+
+    public List<RequestType> getTypeList(String... name) {
+        return Arrays.stream(name)
+                .map(n -> (RequestType)provider.getByName(n))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/RequestTypeProvider.java
@@ -1,25 +1,41 @@
 package ru.pezhe.cmanager.requests.service;
 
 import ru.pezhe.cmanager.requests.entity.RequestType;
+import ru.pezhe.cmanager.requests.service.common.SimpleProvider;
 
-public class RequestTypeProvider {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
 
-    private final RequestType stubType;
+public class RequestTypeProvider implements SimpleProvider {
+
+    private final List<RequestType> types = new ArrayList<>();
     private final static RequestTypeProvider instance = new RequestTypeProvider();
 
     private RequestTypeProvider() {
-        this.stubType = new RequestType("id", "stub_type", "none");
-        this.stubType.getRequiredOptions().add("option_1");
-        this.stubType.getRequiredOptions().add("option_2");
-        this.stubType.getRequiredOptions().add("option_3");
+        RequestType stubType = new RequestType("id_1", "stub_type_1", "none");
+        stubType.getRequiredOptions().add("option_1");
+        stubType.getRequiredOptions().add("option_2");
+        stubType.getRequiredOptions().add("option_3");
+        this.types.add(stubType);
+        stubType = new RequestType("id_2", "stub_type_2", "none");
+        stubType.getRequiredOptions().add("option_4");
+        stubType.getRequiredOptions().add("option_5");
+        stubType.getRequiredOptions().add("option_6");
+        this.types.add(stubType);
     }
 
     public static RequestTypeProvider getInstance() {
         return instance;
     }
 
+    @Override
     public RequestType getByName(String typeName) {
-        return this.stubType;
+        return types
+                .stream()
+                .filter(t -> t.getName().equals(typeName))
+                .findAny()
+                .orElseThrow(NoSuchElementException::new);
     }
 
 }

--- a/src/main/java/ru/pezhe/cmanager/requests/service/common/ComplexProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/common/ComplexProvider.java
@@ -1,0 +1,11 @@
+package ru.pezhe.cmanager.requests.service.common;
+
+public abstract class ComplexProvider implements SimpleProvider {
+
+    protected final SimpleProvider provider;
+
+    public ComplexProvider(SimpleProvider simpleProvider) {
+        this.provider = simpleProvider;
+    }
+
+}

--- a/src/main/java/ru/pezhe/cmanager/requests/service/common/SimpleProvider.java
+++ b/src/main/java/ru/pezhe/cmanager/requests/service/common/SimpleProvider.java
@@ -1,0 +1,7 @@
+package ru.pezhe.cmanager.requests.service.common;
+
+public interface SimpleProvider {
+
+    Object getByName(String name);
+
+}


### PR DESCRIPTION
Для двух провайдеров, возвращающих тип запроса и службу исполнителя (RequestTypeProvider и PublicServiceProvider), создан общий интерфейс (SimpleProvider) с методом getByName и абстрактный декоратор (ComplexProvider). Для провайдера типов запросов (RequestTypeProvider) создан декоратор (RequestTypeExtendedProvider), позволяющий получать лист типов запросов по списку имён (пока не понятно зачем, пришлось задачу притянуть за уши :)). При этом класс декоратора реализует базовый интерфейс провайдера и может быть использован вместо него. То есть решена проблема расширения функциональности класса без наследования, которое невозможно из-за того, что расширяемый класс (RequestTypeProvider) реализует шаблон Singleton и имеет приватный конструктор.